### PR TITLE
[software.eessi.io] Ingest eessi-2025.06-software-linux-aarch64-a64fx-17528657880.tar.gz :closed_lock_with_key:

### DIFF
--- a/approved/2025.06/software/linux/aarch64/a64fx/17528657880/eessi-2025.06-software-linux-aarch64-a64fx-17528657880.tar.gz.meta.txt
+++ b/approved/2025.06/software/linux/aarch64/a64fx/17528657880/eessi-2025.06-software-linux-aarch64-a64fx-17528657880.tar.gz.meta.txt
@@ -1,0 +1,19 @@
+{
+  "uploader": {
+    "username": "eessibot",
+    "ip": "194.210.49.1",
+    "hostname": "ln01-x86"
+  },
+  "payload": {
+    "filename": "eessi-2025.06-software-linux-aarch64-a64fx-17528657880.tar.gz",
+    "size": "23144897",
+    "ctime": "Fri Jul 18 20:10:14 WEST 2025",
+    "sha256sum": "f166f19e4e18fbe6e25825990f4b2b8dfedf03e1bc1b5b648511a3d45f862d97",
+    "url": "https://software.eessi.io-2025.06.s3.amazonaws.com/2025.06/software/linux/aarch64/a64fx/17528657880/eessi-2025.06-software-linux-aarch64-a64fx-17528657880.tar.gz"
+  },
+  "link2pr": {
+    "repo": "EESSI/software-layer",
+    "pr": "1140",
+    "pr_comment_id": "3090381999"
+  }
+}


### PR DESCRIPTION
A new tarball has been staged for https://github.com/EESSI/software-layer/pull/1140.
Please review the contents of this tarball carefully.
Merging this PR will lead to automatic ingestion of the tarball to the repository software.eessi.io.

<details>
<summary>Metadata of tarball</summary>

```
{
  "uploader": {
    "username": "eessibot",
    "ip": "194.210.49.1",
    "hostname": "ln01-x86"
  },
  "payload": {
    "filename": "eessi-2025.06-software-linux-aarch64-a64fx-17528657880.tar.gz",
    "size": "23144897",
    "ctime": "Fri Jul 18 20:10:14 WEST 2025",
    "sha256sum": "f166f19e4e18fbe6e25825990f4b2b8dfedf03e1bc1b5b648511a3d45f862d97",
    "url": "https://software.eessi.io-2025.06.s3.amazonaws.com/2025.06/software/linux/aarch64/a64fx/17528657880/eessi-2025.06-software-linux-aarch64-a64fx-17528657880.tar.gz"
  },
  "link2pr": {
    "repo": "EESSI/software-layer",
    "pr": "1140",
    "pr_comment_id": "3090381999"
  }
}

```

</details>

<details>
<summary>Overview of tarball contents</summary>

Total number of items in the tarball: 30921
URL to the tarball: https://software.eessi.io-2025.06.s3.amazonaws.com/2025.06/software/linux/aarch64/a64fx/17528657880/eessi-2025.06-software-linux-aarch64-a64fx-17528657880.tar.gz
Summarized overview of the contents of the tarball:
```
2025.06/software/linux/aarch64/a64fx/modules/all/EasyBuild/5.1.1.lua
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/EasyBuild-5.1.1-easybuild-devel
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/EasyBuild-5.1.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/EasyBuild-5.1.1_fix-failing-copy-of-readonly-patches.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easybuild-EasyBuild-5.1.1-20250718.200809.log.bz2
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/.eb-path-index
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/0/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/0/4ti2/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/0/4ti2/4ti2-1.6.10-GCC-13.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/0/4ti2/4ti2-1.6.9-GCC-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABAQUS/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABAQUS/ABAQUS-2021-hotfix-2132.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABAQUS/ABAQUS-2022-hotfix-2214.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABAQUS/ABAQUS-2022-hotfix-2223.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABAQUS/ABAQUS-2022.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABAQUS/ABAQUS-2023-hotfix-2324.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABAQUS/ABAQUS-2023.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABAQUS/ABAQUS-2024-hotfix-2405.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABAQUS/ABAQUS-2024-hotfix-2424.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABAQUS/ABAQUS-2024-hotfix-2441.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABINIT/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABINIT/ABINIT-10.2.5-intel-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABINIT/ABINIT-9.10.3-intel-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABINIT/ABINIT-9.4.2-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABINIT/ABINIT-9.4.2-intel-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABINIT/ABINIT-9.6.2-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABINIT/ABINIT-9.6.2-intel-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABINIT/ABINIT-9.6.2-intel-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABINIT/ABINIT-9.6.2-intel-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABRicate/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABRicate/ABRicate-1.0.0-gompi-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABRicate/ABRicate-1.0.0-gompi-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABRicate/ABRicate-1.0.0-gompi-2023b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABySS/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABySS/ABySS-2.3.10-foss-2024a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ABySS/ABySS-2.3.7-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ACTC/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ACTC/ACTC-1.1-GCCcore-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ACTC/ACTC-1.1-GCCcore-12.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AEDT/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AEDT/AEDT-2024R1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AEDT/AEDT-2025R1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AFNI/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AFNI/AFNI-24.0.02-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AFNI/AFNI-25.1.01-foss-2024a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AGAT/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AGAT/AGAT-0.9.2-GCC-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AGAT/AGAT-1.1.0-GCC-12.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AGAT/AGAT-1.4.0-GCC-12.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AGeNT/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AGeNT/AGeNT-3.0.6.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AICSImageIO/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AICSImageIO/AICSImageIO-4.14.0-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ALAMODE/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ALAMODE/ALAMODE-1.4.2-foss-2022b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ALL/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ALL/ALL-0.9.2-foss-2022b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ALL/ALL-0.9.2-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ALL/ALL-0.9.2-foss-2023b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMAPVox/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMAPVox/AMAPVox-1.9.4-Java-11.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMD-uProf/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMD-uProf/AMD-uProf-3.4.502.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMD-uProf/AMD-uProf-3.5.671.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMD-uProf/AMD-uProf-4.1.424.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMD-uProf/AMD-uProf-5.0.1479.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMD-uProf/AMD-uProf-5.1.701.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMGX/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMGX/AMGX-2.4.0-foss-2023a-CUDA-12.1.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMGX/AMGX-2.4.0_external-thrust.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMGX/AMGX-2.4.0_fix-openmp-linking.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMICA/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMICA/AMICA-2024.1.19-intel-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMOS/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMOS/AMOS-3.1.0-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMOS/AMOS-3.1.0-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMOS/AMOS-3.1.0_GCC-4.7.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMOS/AMOS-3.1.0_fix_deprecated_maxmatch-flag.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMOS/AMOS-3.1.0_link_correctly_to_DELTAFILER_SHOWCOORDS.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMPtk/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMPtk/AMPtk-1.5.4-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMRFinderPlus/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMRFinderPlus/AMRFinderPlus-3.11.18-gompi-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMRFinderPlus/AMRFinderPlus-3.11.18-gompi-2022b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMRFinderPlus/AMRFinderPlus-3.12.8-gompi-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMS/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMS/AMS-2022.102-iimpi-2021b-intelmpi.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMS/AMS-2023.101-iimpi-2022a-intelmpi.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AMS/AMS-2023.104-iimpi-2022b-intelmpi.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANIcalculator/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANIcalculator/ANIcalculator-1.0-GCCcore-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANIcalculator/ANIcalculator-1.0-GCCcore-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANSYS/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANSYS/ANSYS-2022R1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANSYS/ANSYS-2022R2.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANSYS/ANSYS-2023R1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANSYS/ANSYS-2024R1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANSYS/ANSYS-2025R1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTIC/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTIC/ANTIC-0.2.5-gfbf-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTLR/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTLR/ANTLR-2.7.7-GCCcore-10.3.0-Java-11.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTLR/ANTLR-2.7.7-GCCcore-11.2.0-Java-11.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTLR/ANTLR-2.7.7-GCCcore-11.3.0-Java-11.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTLR/ANTLR-2.7.7-GCCcore-12.3.0-Java-11.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTLR/ANTLR-2.7.7-GCCcore-13.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTLR/ANTLR-2.7.7_includes.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTs/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTs/ANTs-2.3.5-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTs/ANTs-2.5.0-foss-2022b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTx2/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ANTx2/ANTx2-20250512.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCC/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCC/AOCC-3.0.0-GCCcore-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCC/AOCC-3.1.0-GCCcore-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCC/AOCC-3.1.0-GCCcore-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCC/AOCC-3.2.0-GCCcore-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCC/AOCC-3.2.0-GCCcore-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCC/AOCC-4.0.0-GCCcore-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCC/AOCC-4.0.0-GCCcore-12.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCC/AOCC-4.0.0-GCCcore-12.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCC/AOCC-4.2.0-GCCcore-13.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCC/AOCC-5.0.0-GCCcore-14.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCL-BLAS/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCL-BLAS/AOCL-BLAS-5.0-GCC-13.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOCL-BLAS/AOCL-BLAS-5.0-GCC-14.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOFlagger/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOFlagger/AOFlagger-3.4.0-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AOFlagger/AOFlagger-3.4.0-foss-2023b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APOST3D/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APOST3D/APOST3D-20240527-intel-compilers-2023.1.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR-util/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR-util/APR-util-1.6.1-GCCcore-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR-util/APR-util-1.6.1-GCCcore-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR-util/APR-util-1.6.1-GCCcore-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR-util/APR-util-1.6.3-GCCcore-12.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR-util/APR-util-1.6.3-GCCcore-13.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR-util/APR-util-1.6.3-GCCcore-14.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR/APR-1.7.0-GCCcore-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR/APR-1.7.0-GCCcore-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR/APR-1.7.0-GCCcore-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR/APR-1.7.4-GCCcore-12.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR/APR-1.7.4-GCCcore-13.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/APR/APR-1.7.6-GCCcore-14.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ARAGORN/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ARAGORN/ARAGORN-1.2.41-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ARGoS/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ARGoS/ARGoS-3.0.0-beta59-GCC-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAGI/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAGI/ASAGI-1.0-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAGI/ASAGI-1.0_fix-level.h.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP/ASAP-2.0-foss-2021a-CUDA-11.3.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP/ASAP-2.0_libjpeg.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP/ASAP-2.0_use_pugixml_shared.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP/ASAP-2.1-cmath.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP/ASAP-2.1-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP/ASAP-2.1-libjpeg.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP/ASAP-2.1-pugixml.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP3/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP3/ASAP3-3.13.2-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP3/ASAP3-3.13.3-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP3/ASAP3-3.13.3-intel-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP3/ASAP3-3.13.7-foss-2023a-ASE-3.24.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASAP3/ASAP3-3.13.7-intel-2023a-ASE-3.24.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASCAT/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASCAT/ASCAT-3.1.2-foss-2022a-R-4.2.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASCAT/ASCAT-3.1.2-foss-2022b-R-4.2.2.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.0-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.0-intel-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.1-Compatibility-with-Flask-2-2-2.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.1-Compatibility-with-Scipy-2022-05.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.1-Compatibility-with-pytest-from-Python-3-10.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.1-Compatibility-with-pytest-part-2.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.1-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.1-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.1-gfbf-2022b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.1-gfbf-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.1-gomkl-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.1-iimkl-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.1-intel-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.22.1-intel-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.23.0-gfbf-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.23.0-gfbf-2023b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.23.0-gfbf-2024a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.23.0-iimkl-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.24.0-gfbf-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.24.0-gfbf-2024a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.24.0-iimkl-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASE/ASE-3.25.0-gfbf-2024a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASF-SearchAPI/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ASF-SearchAPI/ASF-SearchAPI-6.5.0-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ATK/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ATK/ATK-2.36.0-GCCcore-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ATK/ATK-2.36.0-GCCcore-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ATK/ATK-2.38.0-GCCcore-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ATK/ATK-2.38.0-GCCcore-12.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ATK/ATK-2.38.0-GCCcore-12.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ATK/ATK-2.38.0-GCCcore-13.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ATK/ATK-2.38.0-GCCcore-13.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUGUSTUS/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.4.0-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.4.0-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.4.0_fix-hardcoding.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.5.0-20240612-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.5.0-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.5.0-foss-2022b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.5.0-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.5.0-foss-2023b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.5.0-foss-2024a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUGUSTUS/AUGUSTUS-3.5.0_fix-gcc13.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUTO-07p/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AUTO-07p/AUTO-07p-0.9.3-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Abseil/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Abseil/Abseil-20210324.2-GCCcore-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Abseil/Abseil-20230125.2-GCCcore-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Abseil/Abseil-20230125.2-GCCcore-12.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Abseil/Abseil-20230125.3-GCCcore-12.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Abseil/Abseil-20240116.1-GCCcore-13.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Abseil/Abseil-20240722.0-GCCcore-13.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Abseil/Abseil-20250512.1-GCCcore-14.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AdapterRemoval/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AdapterRemoval/AdapterRemoval-2.3.2-GCC-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AdapterRemoval/AdapterRemoval-2.3.2-GCC-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AdapterRemoval/AdapterRemoval-2.3.3-GCC-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Advisor/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Advisor/Advisor-2021.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Advisor/Advisor-2021.4.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Advisor/Advisor-2022.1.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Advisor/Advisor-2023.0.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Advisor/Advisor-2023.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Advisor/Advisor-2025.0.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Albumentations/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Albumentations/Albumentations-1.1.0-foss-2021a-CUDA-11.3.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Albumentations/Albumentations-1.1.0-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Albumentations/Albumentations-1.3.0-foss-2022a-CUDA-11.7.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Albumentations/Albumentations-1.3.0-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Albumentations/Albumentations-1.4.0-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Alfred/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Alfred/Alfred-0.2.6-GCC-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.0.0_fix-packages.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.0.0_n-cpu.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.0.1_setup_rm_tfcpu.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.1.0_fix-scp-path.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.1.2-foss-2021a-CUDA-11.3.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.1.2-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.1.2_data-dep-paths.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.1_fix-alphafold-tests.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.2.2-foss-2021a-CUDA-11.3.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.2.2-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.2.2_jax038_NaN.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.0-foss-2021b-CUDA-11.4.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.0_data-dep-paths.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.1-foss-2022a-CUDA-11.7.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.1-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.1_use_openmm_7.7.0.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.2-foss-2023a-CUDA-12.1.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.2_BioPythonPDBData.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.2_data-dep-paths-shebang-UniRef30.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.2_use_openmm_8.0.0.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.4-foss-2022a-CUDA-11.7.0-ColabFold.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-2.3.4-foss-2022a-ColabFold.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-ColabFold-2.3.4_data-dep-paths.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaFold/AlphaFold-ColabFold-2.3.4_fix-scp-path.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaPulldown/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaPulldown/AlphaPulldown-2.0.0-foss-2023a-CUDA-12.1.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaPulldown/AlphaPulldown-2.0.0b2_fix-import-protein_letters_3to1.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaPulldown/AlphaPulldown-2.0.0b4-foss-2022a-CUDA-11.7.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaPulldown/AlphaPulldown-2.0.0b4-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaPulldown/AlphaPulldown-2.0.3-foss-2023a-CUDA-12.1.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AlphaPulldown/AlphaPulldown-2.0.3-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-22.0-foss-2021b-AmberTools-22.3-CUDA-11.4.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-22.0-foss-2021b-AmberTools-22.3.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-22.4-foss-2022a-AmberTools-22.5-CUDA-11.7.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-22_reduce_precision_of_kmmd_test.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-22_remove_undeclared_redundant_variable.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-24.0-foss-2023b-AmberTools-24.0-CUDA-12.4.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-24.0-foss-2023b-AmberTools-24.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-24.0-foss-2024a-AmberTools-24.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-24.3-foss-2023a-AmberTools-24.10-CUDA-12.1.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-24.3-foss-2023a-AmberTools-24.10.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-24_CudaConfig.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-24_reduce_precision_of_kmmd_pmemd_gb_test.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/Amber-24_skip-TempRem-tests.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/AmberTools-20_cmake-locate-netcdf.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/AmberTools-20_fix_missing_MPI_LIBRARY_error.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Amber/AmberTools-20_fix_xblas_missing_make_dependency.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-20_cmake-locate-netcdf.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-20_fix_missing_MPI_LIBRARY_error.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-20_fix_xblas_missing_make_dependency.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21-intel-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21.12-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21_CMake-FlexiBLAS.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21_dont_include_config.h_in_top_Makefile.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21_fix_DGESVD_workspace_query.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21_fix_incorrect_dvout_call.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21_fix_incorrect_mexit_calls.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21_fix_more_blas_argument_problems.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21_fix_multiple_definition.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21_fix_potential_use_before_init.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21_fix_rism_argument_mismatch.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-21_fix_xray_fftpack_arg_mismatch.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-22.3-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-22_fix_cuda_version_check.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-22_fix_missing_error_check_on_test_run.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-22_fix_test_missing_cuda_dir.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AmberTools/AmberTools-23.6-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Anaconda3/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2020.07.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2020.11.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2021.05.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2021.11.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2022.05.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2022.10.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2023.03-1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2023.07-2.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2023.09-0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2024.02-1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Anaconda3/Anaconda3-2024.06-1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Annocript/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Annocript/Annocript-2.0-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Annocript/annocript_fix_paths.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Annocript/annocript_no_background.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arb/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arb/Arb-2.19.0-GCC-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arb/Arb-2.22.1-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arb/Arb-2.23.0-gfbf-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arcade-Learning-Environment/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arcade-Learning-Environment/Arcade-Learning-Environment-0.7.3-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arcade-Learning-Environment/Arcade-Learning-Environment-0.8.1-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arcade-Learning-Environment/Arcade-Learning-Environment-0.8.1-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arcade-Learning-Environment/ale-py-0.8.1_fix_version.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArchR/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArchR/ArchR-1.0.1-foss-2021b-R-4.1.2.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArchR/ArchR-1.0.2-20220704-foss-2023a-R-4.3.2.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArchR/ArchR-1.0.2-foss-2022b-R-4.2.2.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArchR/ArchR-1.0.2-foss-2023a-R-4.3.2.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArchR/ArchR-1.0.3-foss-2023b-R-4.4.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Archive-Zip/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Archive-Zip/Archive-Zip-1.68-GCCcore-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Archive-Zip/Archive-Zip-1.68-GCCcore-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Archive-Zip/Archive-Zip-1.68-GCCcore-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Archive-Zip/Archive-Zip-1.68-GCCcore-12.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Archive-Zip/Archive-Zip-1.68-GCCcore-12.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Archive-Zip/Archive-Zip-1.68-GCCcore-13.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Archive-Zip/Archive-Zip-1.68-GCCcore-13.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AreTomo2/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AreTomo2/AreTomo2-1.0.0-GCCcore-12.3.0-CUDA-12.1.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AreTomo2/AreTomo2-1.0.0_makefile.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Armadillo/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Armadillo/Armadillo-10.7.5-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Armadillo/Armadillo-11.4.3-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Armadillo/Armadillo-11.4.3-foss-2022b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Armadillo/Armadillo-12.6.2-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Armadillo/Armadillo-12.8.0-foss-2023b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Armadillo/Armadillo-14.0.3-foss-2024a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arriba/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arriba/Arriba-2.1.0-GCC-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arriba/Arriba-2.2.1-GCC-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arriba/Arriba-2.3.0-GCC-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arriba/Arriba-2.4.0-GCC-12.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/Arrow-11.0.0-gfbf-2022b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/Arrow-14.0.1-gfbf-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/Arrow-16.1.0-gfbf-2023b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/Arrow-17.0.0-gfbf-2024a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/Arrow-6.0.0-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/Arrow-6.0.0-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/Arrow-6.0.1-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/Arrow-8.0.0-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/Arrow-8.0.0-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/Arrow-8.0.0-foss-2022.05.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/Arrow-8.0.0-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Arrow/Arrow-8.0.0_fix-BaseExtensionType-arrow-ext-methods.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Artemis/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Artemis/Artemis-18.0.2-Java-11.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Artemis/Artemis-18.0.3-Java-11.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Artemis/Artemis-18.2.0-Java-11.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArviZ/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArviZ/ArviZ-0.11.4-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArviZ/ArviZ-0.11.4-intel-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArviZ/ArviZ-0.12.1-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArviZ/ArviZ-0.12.1-foss-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArviZ/ArviZ-0.12.1-intel-2022a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArviZ/ArviZ-0.16.1-foss-2023a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/ArviZ/ArviZ-0.21.0-foss-2024a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Aspera-CLI/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Aspera-CLI/Aspera-CLI-3.9.6.1467.159c5b1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Atomsk/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Atomsk/Atomsk-0.13.1-gfbf-2024a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Austin/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Austin/Austin-3.2.0-GCCcore-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Austin/Austin-3.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Auto-WEKA/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Auto-WEKA/Auto-WEKA-2.6-WEKA-3.8.5-Java-11.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AutoDock-GPU/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AutoDock-GPU/AutoDock-GPU-1.5.3-GCC-10.3.0-CUDA-11.3.1.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AutoDock-GPU/AutoDock-GPU-1.5.3-GCC-11.3.0-CUDA-11.7.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AutoDock-Vina/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AutoDock-Vina/AutoDock-Vina-1.1.2-linux_x86.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AutoDock-Vina/AutoDock-Vina-1.2.3-foss-2021a.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AutoDock-Vina/AutoDock-Vina-1.2.3-foss-2021b.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AutoDock/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/AutoDock/AutoDock-4.2.6-GCC-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf-archive/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf-archive/Autoconf-archive-2023.02.20-GCCcore-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf-archive/Autoconf-archive-2023.02.20-GCCcore-12.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.71-GCCcore-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.71-GCCcore-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.71-GCCcore-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.71-GCCcore-12.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.71-GCCcore-12.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.71-GCCcore-13.1.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.71-GCCcore-13.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.71-Port-better-to-NVHPC.patch
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.71.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.72-GCCcore-13.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.72-GCCcore-14.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Autoconf/Autoconf-2.72-GCCcore-14.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Automake/
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Automake/Automake-1.16.3-GCCcore-10.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Automake/Automake-1.16.4-GCCcore-11.2.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.1.1/20250718_190846UTC/easybuild/easyconfigs/a/Automake/Automake-1.16.5-GCCcore-11.3.0.eb
2025.06/software/linux/aarch64/a64fx/reprod/EasyBuild/5.

WARNING: output exceeded the maximum length and was truncated!
```

</details>

:heavy_check_mark: :closed_lock_with_key: The signature of this tarball has been successfully verified:
- `/srv/tmp/tarballs-trz42/eessi-2025.06-software-linux-aarch64-a64fx-17528657880.tar.gz`
  - identity=`EESSI`, namespace=`eessi-bot-deucalion`
- `/srv/tmp/tarballs-trz42/eessi-2025.06-software-linux-aarch64-a64fx-17528657880.tar.gz.meta.txt`
  - identity=`EESSI`, namespace=`eessi-bot-deucalion`
